### PR TITLE
Refactoring of CalendarEventsModel and implementation of Event

### DIFF
--- a/src/Event/BeforeGetSubEventsEvent.php
+++ b/src/Event/BeforeGetSubEventsEvent.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * Copyright (c) 2021 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace HeimrichHannot\EventsBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class BeforeGetSubEventsEvent extends Event
+{
+    public const NAME = 'huh.events.before_get_sub_events';
+    /**
+     * @var string
+     */
+    protected $table;
+    /**
+     * @var array
+     */
+    protected $columns;
+    /**
+     * @var array
+     */
+    protected $values;
+    /**
+     * @var array
+     */
+    protected $options;
+
+    public function __construct(string $table, array $columns, array $values, array $options)
+    {
+        $this->table = $table;
+        $this->columns = $columns;
+        $this->values = $values;
+        $this->options = $options;
+    }
+
+    public function getTable(): string
+    {
+        return $this->table;
+    }
+
+    public function setTable(string $table): void
+    {
+        $this->table = $table;
+    }
+
+    public function getColumns(): array
+    {
+        return $this->columns;
+    }
+
+    public function setColumns(array $columns): void
+    {
+        $this->columns = $columns;
+    }
+
+    public function getValues(): array
+    {
+        return $this->values;
+    }
+
+    public function setValues(array $values): void
+    {
+        $this->values = $values;
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    public function setOptions(array $options): void
+    {
+        $this->options = $options;
+    }
+}

--- a/src/Event/BeforeGetSubEventsEvent.php
+++ b/src/Event/BeforeGetSubEventsEvent.php
@@ -12,7 +12,6 @@ use Symfony\Component\EventDispatcher\Event;
 
 class BeforeGetSubEventsEvent extends Event
 {
-    public const NAME = 'huh.events.before_get_sub_events';
     /**
      * @var string
      */

--- a/src/Manager/EventsManager.php
+++ b/src/Manager/EventsManager.php
@@ -12,10 +12,12 @@ use Contao\Config;
 use Contao\Controller;
 use Contao\DataContainer;
 use Contao\System;
+use HeimrichHannot\EventsBundle\Event\BeforeGetSubEventsEvent;
 use HeimrichHannot\EventsBundle\EventListener\DataContainer\CalendarEventsListener;
 use HeimrichHannot\EventsBundle\EventListener\DataContainer\CalendarSubEventsListener;
 use HeimrichHannot\UtilsBundle\Arrays\ArrayUtil;
 use HeimrichHannot\UtilsBundle\Model\ModelUtil;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class EventsManager
 {
@@ -27,11 +29,16 @@ class EventsManager
      * @var ArrayUtil
      */
     protected $arrayUtil;
+    /**
+     * @var EventDispatcherInterface
+     */
+    protected $eventDispatcher;
 
-    public function __construct(ModelUtil $modelUtil, ArrayUtil $arrayUtil)
+    public function __construct(ModelUtil $modelUtil, ArrayUtil $arrayUtil, EventDispatcherInterface $eventDispatcher)
     {
         $this->modelUtil = $modelUtil;
         $this->arrayUtil = $arrayUtil;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     public function initCalendarSubEventsConfig()
@@ -219,5 +226,37 @@ class EventsManager
 
             $dca['fields']['alias']['eval']['tl_class'] = 'w50';
         }
+    }
+
+    /**
+     * Checks a given event has sub events.
+     */
+    public function hasSubEvents(int $eventId): bool
+    {
+        return null !== $this->getSubEvents($eventId);
+    }
+
+    /**
+     * Retrieves the sub events for a given event.
+     *
+     * @return mixed
+     */
+    public function getSubEvents(int $eventId, array $options = [])
+    {
+        if (CalendarSubEventsListener::SUB_EVENT_MODE_ENTITY === Config::get('subEventMode')) {
+            $table = 'tl_calendar_sub_events';
+            $parentProperty = 'tl_calendar_events.pid';
+        } elseif (CalendarSubEventsListener::SUB_EVENT_MODE_RELATION === Config::get('subEventMode')) {
+            $table = 'tl_calendar_events';
+            $parentProperty = 'tl_calendar_events.parentEvent';
+        } else {
+            return null;
+        }
+
+        $event = $this->eventDispatcher->dispatch(BeforeGetSubEventsEvent::NAME, new BeforeGetSubEventsEvent($table, [$parentProperty.'=?'], [$eventId], $options));
+
+        return System::getContainer()->get(ModelUtil::class)->findModelInstancesBy(
+            $event->getTable(), $event->getColumns(), $event->getValues(), $event->getOptions()
+        );
     }
 }

--- a/src/Manager/EventsManager.php
+++ b/src/Manager/EventsManager.php
@@ -253,9 +253,9 @@ class EventsManager
             return null;
         }
 
-        $event = $this->eventDispatcher->dispatch(BeforeGetSubEventsEvent::NAME, new BeforeGetSubEventsEvent($table, [$parentProperty.'=?'], [$eventId], $options));
+        $event = $this->eventDispatcher->dispatch(BeforeGetSubEventsEvent::class, new BeforeGetSubEventsEvent($table, [$parentProperty.'=?'], [$eventId], $options));
 
-        return System::getContainer()->get(ModelUtil::class)->findModelInstancesBy(
+        return $this->modelUtil->findModelInstancesBy(
             $event->getTable(), $event->getColumns(), $event->getValues(), $event->getOptions()
         );
     }

--- a/src/Model/CalendarEventsModel.php
+++ b/src/Model/CalendarEventsModel.php
@@ -8,9 +8,8 @@
 
 namespace HeimrichHannot\EventsBundle\Model;
 
-use Contao\Config;
 use Contao\System;
-use HeimrichHannot\EventsBundle\EventListener\DataContainer\CalendarSubEventsListener;
+use HeimrichHannot\EventsBundle\Manager\EventsManager;
 use HeimrichHannot\UtilsBundle\Model\ModelUtil;
 
 class CalendarEventsModel extends \Contao\CalendarEventsModel
@@ -23,7 +22,7 @@ class CalendarEventsModel extends \Contao\CalendarEventsModel
      */
     public static function hasSubEvents(int $event): bool
     {
-        return null !== static::getSubEvents($event);
+        return null !== System::getContainer()->get(EventsManager::class)->getSubEvents($event);
     }
 
     /**
@@ -36,19 +35,7 @@ class CalendarEventsModel extends \Contao\CalendarEventsModel
      */
     public static function getSubEvents(int $event, array $options = [])
     {
-        if (CalendarSubEventsListener::SUB_EVENT_MODE_ENTITY === Config::get('subEventMode')) {
-            $table = 'tl_calendar_sub_events';
-            $parentProperty = 'tl_calendar_events.pid';
-        } elseif (CalendarSubEventsListener::SUB_EVENT_MODE_RELATION === Config::get('subEventMode')) {
-            $table = 'tl_calendar_events';
-            $parentProperty = 'tl_calendar_events.parentEvent';
-        } else {
-            return null;
-        }
-
-        return System::getContainer()->get(ModelUtil::class)->findModelInstancesBy(
-            $table, [$parentProperty.'=?'], [$event], $options
-        );
+        return System::getContainer()->get(EventsManager::class)->getSubEvents($event, $options);
     }
 
     public static function findPublishedByIdOrAlias($varId, array $options = [])

--- a/src/Model/CalendarEventsModel.php
+++ b/src/Model/CalendarEventsModel.php
@@ -17,6 +17,9 @@ class CalendarEventsModel extends \Contao\CalendarEventsModel
 {
     /**
      * Checks a given event has sub events.
+     *
+     * @deprecated Deprecated since 1.7.0, to be removed in 2.0.
+     *             Use EventsManager::hasSubEvents instead.
      */
     public static function hasSubEvents(int $event): bool
     {
@@ -27,6 +30,9 @@ class CalendarEventsModel extends \Contao\CalendarEventsModel
      * Retrieves the sub events for a given event.
      *
      * @return mixed
+     *
+     * @deprecated Deprecated since Contao 1.7.0, to be removed in 2.0.
+     *             Use EventsManager::getSubEvents instead.
      */
     public static function getSubEvents(int $event, array $options = [])
     {


### PR DESCRIPTION
As in the previous PR it was not possible to use Events, because EventDispatcherInterface is not public. This was also a bad design to use Events in Model. This refactoring fixes all this issues. And implements DI in for this Methods.

* deprecated CalendarEventsModel::getSubEvents
* deprecated CalendarEventsModel::hasSubEvents
* added EventsManager::getSubEvents
* added EventsManager::hasSubEvents
* added Event for manipulation of EventsManager::getSubEvents query